### PR TITLE
Fix CI job issues and errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,9 @@ jobs:
         run: |
           echo "=== Creating optional 'root' PostgreSQL role (ignore errors) ==="
           set +e  # Do not fail if role already exists
-          PGPASSWORD=postgres psql -h localhost -U postgres -d postgres -c "DO $$BEGIN IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = 'root') THEN CREATE ROLE root WITH LOGIN PASSWORD 'postgres'; END IF; END$$;" || true
+          # Escape the $$ delimiters (\$\$) inside the double-quoted string so that Bash does **not** replace them with the current PID.
+          # This keeps the DO/END block syntactically correct for PostgreSQL.
+          PGPASSWORD=postgres psql -h localhost -U postgres -d postgres -c "DO \$\$BEGIN IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = 'root') THEN CREATE ROLE root WITH LOGIN PASSWORD 'postgres'; END IF; END\$\$;" || true
           PGPASSWORD=postgres psql -h localhost -U postgres -d postgres -c "ALTER ROLE root CREATEDB;" || true
           set -e
  


### PR DESCRIPTION
Fix PostgreSQL role creation command by escaping `$$` delimiters.

The `$$` delimiters in the `psql` command were being replaced by the shell's PID, causing a syntax error in the SQL. Escaping them ensures the command is passed correctly to PostgreSQL.